### PR TITLE
Issue #5 toggle events broken in firefox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "io.magentys"
 
 description := "Magentys Donut - Reporting Tool"
 
-version := "0.0.1"
+version := "0.0.2"
 
 scalaVersion := "2.11.7"
 

--- a/src/main/resources/templates/default/index.html
+++ b/src/main/resources/templates/default/index.html
@@ -430,7 +430,7 @@
     <div class="row">
         <div class="col-lg-12">
             <h3>Failures ({{failuresPage.totalFailures}})
-                <a id="toggleFailuresButton" href="" onclick="toggleAllFailures()" class="btn btn-default btn-xs hide">toggle all <span class="glyphicon glyphicon-menu-down"></span></a>
+                <a id="toggleFailuresButton" href="" onclick="toggleAllFailures(event)" class="btn btn-default btn-xs hide">toggle all <span class="glyphicon glyphicon-menu-down"></span></a>
             </h3>
             <br>
             {{failuresPage.htmlElements}}
@@ -519,26 +519,25 @@
     };
 
   /* SCENARIOS FUNCTIONS */
-  function toggleScenario(id) {
+  function toggleScenario(id, event) {
     event.preventDefault();
     $('#'+id).slideToggle('slow');
-  }
+  };
 
-  function toggleAllFailures() {
+  function toggleAllFailures(event) {
     var idsArray = $('#failureIds').val().split(",");
 
     for(var i = 0; i < idsArray.length; i++){
-        toggleScenario(idsArray[i]);
+        toggleScenario(idsArray[i], event);
     }
-  }
+  };
 
   /* SCREENSHOT FUNCTIONS */
-
-   function toggleScreenshot(id,type, imageIds) {
+   function toggleScreenshot(id, type, imageIds, event) {
         event.preventDefault();
         var screenshotId = '#'+ type.trim() +'-'+id.trim();
         getAllImagesForScenario(screenshotId, imageIds);
-        $(screenshotId).slideToggle('slow');
+        $(screenshotId).slideToggle('slow').focus();
         return false;
     };
 

--- a/src/main/resources/templates/light/index.html
+++ b/src/main/resources/templates/light/index.html
@@ -430,7 +430,7 @@
     <div class="row">
         <div class="col-lg-12">
             <h3>Failures ({{failuresPage.totalFailures}})
-                <a id="toggleFailuresButton" href="" onclick="toggleAllFailures()" class="btn btn-default btn-xs hide">toggle all <span class="glyphicon glyphicon-menu-down"></span></a>
+                <a id="toggleFailuresButton" href="" onclick="toggleAllFailures(event)" class="btn btn-default btn-xs hide">toggle all <span class="glyphicon glyphicon-menu-down"></span></a>
             </h3>
             <br>
             {{failuresPage.htmlElements}}
@@ -519,26 +519,25 @@
     };
 
   /* SCENARIOS FUNCTIONS */
-  function toggleScenario(id) {
+  function toggleScenario(id, event) {
     event.preventDefault();
     $('#'+id).slideToggle('slow');
-  }
+  };
 
-  function toggleAllFailures() {
+  function toggleAllFailures(event) {
     var idsArray = $('#failureIds').val().split(",");
 
     for(var i = 0; i < idsArray.length; i++){
-        toggleScenario(idsArray[i]);
+        toggleScenario(idsArray[i], event);
     }
-  }
+  };
 
   /* SCREENSHOT FUNCTIONS */
-
-   function toggleScreenshot(id,type, imageIds) {
+   function toggleScreenshot(id, type, imageIds, event) {
         event.preventDefault();
         var screenshotId = '#'+ type.trim() +'-'+id.trim();
         getAllImagesForScenario(screenshotId, imageIds);
-        $(screenshotId).slideToggle('slow');
+        $(screenshotId).slideToggle('slow').focus();
         return false;
     };
 

--- a/src/main/scala/io/magentys/donut/gherkin/processors/HTMLProcessor.scala
+++ b/src/main/scala/io/magentys/donut/gherkin/processors/HTMLProcessor.scala
@@ -73,7 +73,7 @@ private[processors] object HTMLProcessor {
        |        $backgroundHtml
        |        <p class="scenario">
        |          <b>$icon ${element.keyword} </b>${element.name}
-       |          <a href="#" class="btn btn-default btn-xs pull-right toggle-button" onclick=toggleScenario('ul-$parentType-$index')>
+       |          <a href="#" class="btn btn-default btn-xs pull-right toggle-button" onclick="toggleScenario('ul-$parentType-$index', event)">
        |            <span class="glyphicon glyphicon-menu-down"></span>
        |          </a>
        |          <span class="durationBadge pull-right">${element.duration.durationStr} </span>
@@ -124,7 +124,7 @@ private[processors] object HTMLProcessor {
 
   def scenariosScreenshots(index: String, style: String, screenshotsIds: String, screenshotsSize: Int, parentType: String) = {
     s"""
-       |<a href="#" id="openScreenshotsFeatures-$index" onclick="toggleScreenshot('$index', 'screenshot-$parentType', '$screenshotsIds')" style="$style">screenshots (${screenshotsSize})</a>
+       |<a href="#" id="openScreenshotsFeatures-$index" onclick="toggleScreenshot('$index', 'screenshot-$parentType', '$screenshotsIds', event)" style="$style">screenshots (${screenshotsSize})</a>
        |   <div id="screenshot-$parentType-$index" class="row" style="display: none;"></div>
     """.stripMargin
   }


### PR DESCRIPTION
**Problem**: fixes #5, chrome automatically gets the event from the window.event. Firefox doesn't support this.
**Solution**: JQuery abstracts the event handling, so as a solution i inject the event to the broken toggle functions. 
**Tested**: Locally at Chrome-51, Firefox-47, Safari-9